### PR TITLE
added tokens storage logic

### DIFF
--- a/client/src/app/slices/apiSlice.ts
+++ b/client/src/app/slices/apiSlice.ts
@@ -1,14 +1,45 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi, fetchBaseQuery, FetchArgs, BaseQueryApi } from '@reduxjs/toolkit/query/react';
+
+import { RootState } from '../store';
+
+import { setCredentials, logout } from './authSlice';
 
 // All endpoints are defined in the api slice
 
+const baseQuery = fetchBaseQuery({
+  baseUrl:
+    process.env.NODE_ENV === 'production' ? process.env.REACT_APP_BASE_URL_PROD : process.env.REACT_APP_BASE_URL_DEV,
+  credentials: 'include', // to send cookies with requests
+  prepareHeaders(headers, { getState }) {
+    const token = (getState() as RootState).auth.token;
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+    return headers;
+  },
+});
+
+const baseQueryWithReauth = async (args: string | FetchArgs, api: BaseQueryApi, extraOptions: Record<never, never>) => {
+  let result = await baseQuery(args, api, extraOptions);
+
+  if (result?.error?.status === 401) {
+    // request new access token
+    const refreshResult = await baseQuery('/v1/auth/refresh-tokens', api, extraOptions);
+    if (refreshResult?.data) {
+      const user = (api.getState() as RootState).auth.user;
+      // store new access token
+      api.dispatch(setCredentials({ ...refreshResult.data, user }));
+      // retry the original query with new access token
+      result = await baseQuery(args, api, extraOptions);
+    } else {
+      api.dispatch(logout());
+    }
+  }
+  return result;
+};
+
 export const apiSlice = createApi({
-  baseQuery: fetchBaseQuery({
-    baseUrl:
-      process.env.NODE_ENV === 'production' ? process.env.REACT_APP_BASE_URL_PROD : process.env.REACT_APP_BASE_URL_DEV,
-  }),
+  baseQuery: baseQueryWithReauth,
   endpoints: (builder) => ({
-    getUrl: builder.query({ query: (url) => url }),
+    getUrl: builder.query({ query: (url: string) => url }),
 
     // Register
     registerUser: builder.mutation({
@@ -27,9 +58,18 @@ export const apiSlice = createApi({
         body: data,
       }),
     }),
+
+    // Request Verification Email
+    confirmEmail: builder.mutation({
+      query: (data) => ({
+        url: '/v1/auth/send-verification-email',
+        method: 'POST',
+        body: data,
+      }),
+    }),
   }),
 });
 
 // hooks are automatically generated based on endpoint names
 
-export const { useGetUrlQuery, useRegisterUserMutation, useLoginUserMutation } = apiSlice;
+export const { useGetUrlQuery, useRegisterUserMutation, useLoginUserMutation, useConfirmEmailMutation } = apiSlice;

--- a/client/src/app/slices/authSlice.ts
+++ b/client/src/app/slices/authSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import type { RootState } from '../store';
+
+interface IUser {
+  firstName: string;
+  lastName: string;
+  email: string;
+  id: number;
+}
+
+interface IInitialState {
+  user: IUser | null;
+  token: string | null;
+}
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: { user: null, token: null } as IInitialState,
+  reducers: {
+    setCredentials: (state, action) => {
+      const { user } = action.payload;
+      const accessToken = action.payload.access.token;
+      state.user = user;
+      state.token = accessToken;
+    },
+    logout: (state) => {
+      state.user = null;
+      state.token = null;
+    },
+  },
+});
+
+export const { setCredentials, logout } = authSlice.actions;
+
+export default authSlice.reducer;
+
+export const selectCurrentUser = (state: RootState) => state.auth.user;
+export const selectCurrentToken = (state: RootState) => state.auth.token;

--- a/client/src/app/slices/modalSlice.ts
+++ b/client/src/app/slices/modalSlice.ts
@@ -35,4 +35,4 @@ const modalSlice = createSlice({
 
 export const { closeModal, showModal } = modalSlice.actions;
 
-export default modalSlice;
+export default modalSlice.reducer;

--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -1,11 +1,13 @@
 import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
 
 import { apiSlice } from './slices/apiSlice';
+import authSlice from './slices/authSlice';
 import modalSlice from './slices/modalSlice';
 
 export const store = configureStore({
   reducer: {
-    modal: modalSlice.reducer,
+    auth: authSlice,
+    modal: modalSlice,
     [apiSlice.reducerPath]: apiSlice.reducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(apiSlice.middleware),

--- a/client/src/components/ConfirmEmail/ConfirmEmail.tsx
+++ b/client/src/components/ConfirmEmail/ConfirmEmail.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { useAppDispatch } from '../../app/hooks';
+import { useConfirmEmailMutation } from '../../app/slices/apiSlice';
 import { closeModal, showModal, MODAL_TYPE } from '../../app/slices/modalSlice';
 import Button from '../../common/components/Button/Button';
 
@@ -22,6 +23,20 @@ const ConfirmEmail: FC = () => {
     searchParams.delete('emailConfirmed');
     setSearchParams(searchParams);
   };
+
+  const [verify] = useConfirmEmailMutation();
+
+  const onEmailVerify = async () => {
+    await verify({})
+      .unwrap()
+      .then(() => {
+        dispatch(closeModal());
+      })
+      .catch((error) => {
+        console.log(error.data?.message || error);
+      });
+  };
+
   return (
     <div className={styles.container}>
       <div>
@@ -39,7 +54,7 @@ const ConfirmEmail: FC = () => {
       {emailConfirmed ? (
         <Button label="Login" onClick={onLoginButtonClick} size="small" className={styles.buttonConfirm} />
       ) : (
-        <Button label="Ok" onClick={() => dispatch(closeModal())} size="small" className={styles.buttonConfirm} />
+        <Button label="Ok" onClick={onEmailVerify} size="small" className={styles.buttonConfirm} />
       )}
     </div>
   );

--- a/client/src/components/LoginForm/LoginForm.tsx
+++ b/client/src/components/LoginForm/LoginForm.tsx
@@ -3,6 +3,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 
 import { useAppDispatch } from '../../app/hooks';
 import { useLoginUserMutation } from '../../app/slices/apiSlice';
+import { setCredentials } from '../../app/slices/authSlice';
 import { closeModal, showModal, MODAL_TYPE } from '../../app/slices/modalSlice';
 import Button from '../../common/components/Button/Button';
 import Heading from '../../common/components/Heading/Heading';
@@ -38,16 +39,16 @@ const LoginForm: FC = () => {
   });
 
   const [loginUser] = useLoginUserMutation();
-
   // TODO: Implement errors handler
   const onSubmit: SubmitHandler<IFormInput> = async (values) => {
     await loginUser(values)
       .unwrap()
-      .then(() => {
+      .then((data) => {
+        dispatch(setCredentials(data));
         dispatch(closeModal());
       })
-      .catch(({ data }) => {
-        console.log(data?.message);
+      .catch((error) => {
+        console.log(error.data?.message || error);
       });
   };
 
@@ -80,7 +81,7 @@ const LoginForm: FC = () => {
 
       <div className={styles.formButton}>
         <Button
-          label="Sign Up"
+          label="Sign In"
           isSubmit
           isDisabled={!isValid || !isDirty}
           onClick={handleSubmit(onSubmit)}

--- a/client/src/components/RegisterForm/RegisterForm.tsx
+++ b/client/src/components/RegisterForm/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { Controller, useForm, SubmitHandler } from 'react-hook-form';
 
 import { useAppDispatch } from '../../app/hooks';
 import { useRegisterUserMutation } from '../../app/slices/apiSlice';
+import { setCredentials } from '../../app/slices/authSlice';
 import { showModal, MODAL_TYPE } from '../../app/slices/modalSlice';
 import Button from '../../common/components/Button/Button';
 import Input from '../../common/components/Input/Input';
@@ -79,6 +80,7 @@ const RegisterForm: FC = () => {
   });
 
   const [registerUser] = useRegisterUserMutation();
+
   // TODO: Implement errors handler
   const onSubmit: SubmitHandler<IFormInput> = async (values) => {
     const bodyObject = {
@@ -90,11 +92,12 @@ const RegisterForm: FC = () => {
 
     await registerUser(bodyObject)
       .unwrap()
-      .then(() => {
+      .then((data) => {
+        dispatch(setCredentials(data));
         dispatch(showModal({ content: MODAL_TYPE.CONFIRM_EMAIL }));
       })
-      .catch(({ data }) => {
-        console.log(data?.message);
+      .catch((error) => {
+        console.log(error.data?.message || error);
       });
   };
 

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "compression": "^1.7.4",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
     "cross-spawn": "^7.0.3",

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -5,6 +5,8 @@ const compression = require('compression');
 const cors = require('cors');
 const passport = require('passport');
 const httpStatus = require('http-status');
+const cookieParser = require('cookie-parser');
+const { corsOptions, credentials } = require('./config/corsOptions');
 const config = require('./config/config');
 const morgan = require('./config/morgan');
 const { jwtStrategy } = require('./config/passport');
@@ -26,6 +28,9 @@ app.use(helmet());
 // parse json request body
 app.use(express.json());
 
+// middleware for cookies
+app.use(cookieParser());
+
 // parse urlencoded request body
 app.use(express.urlencoded({ extended: true }));
 
@@ -36,8 +41,8 @@ app.use(xss());
 app.use(compression());
 
 // enable cors
-app.use(cors());
-app.options('*', cors());
+app.use(credentials);
+app.use(cors(corsOptions));
 
 // jwt authentication
 app.use(passport.initialize());

--- a/server/src/config/corsOptions.js
+++ b/server/src/config/corsOptions.js
@@ -1,0 +1,22 @@
+const allowedOrigins = ['https://www.yoursite.com', 'http://localhost:3200', 'http://localhost:3000'];
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (allowedOrigins.indexOf(origin) !== -1 || !origin) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  optionsSuccessStatus: 200,
+};
+
+const credentials = (req, res, next) => {
+  const { origin } = req.headers;
+  if (allowedOrigins.includes(origin)) {
+    res.header('Access-Control-Allow-Credentials', true);
+  }
+  next();
+};
+
+module.exports = { corsOptions, credentials };

--- a/server/src/config/passport.js
+++ b/server/src/config/passport.js
@@ -13,7 +13,7 @@ const jwtVerify = async (payload, done) => {
     if (payload.type !== tokenTypes.ACCESS) {
       throw new Error('Invalid token type');
     }
-    const user = await User.findById(payload.sub);
+    const user = await User.findByPk(payload.sub);
     if (!user) {
       return done(null, false);
     }

--- a/server/src/routes/v1/auth.route.js
+++ b/server/src/routes/v1/auth.route.js
@@ -8,8 +8,8 @@ const router = express.Router();
 
 router.post('/register', validate(authValidation.register), authController.register);
 router.post('/login', validate(authValidation.login), authController.login);
-router.post('/logout', validate(authValidation.logout), authController.logout);
-router.post('/refresh-tokens', validate(authValidation.refreshTokens), authController.refreshTokens);
+router.get('/logout', authController.logout);
+router.get('/refresh-tokens', authController.refreshTokens);
 router.post('/forgot-password', validate(authValidation.forgotPassword), authController.forgotPassword);
 router.post('/reset-password', validate(authValidation.resetPassword), authController.resetPassword);
 router.post('/send-verification-email', auth(), authController.sendVerificationEmail);

--- a/server/src/services/token.service.js
+++ b/server/src/services/token.service.js
@@ -53,7 +53,7 @@ const saveToken = async (token, userId, expires, type, blacklisted = false) => {
  */
 const verifyToken = async (token, type) => {
   const payload = jwt.verify(token, config.jwt.secret);
-  const tokenDoc = await Token.findOne({ token, type, user: payload.sub, blacklisted: false });
+  const tokenDoc = await Token.findOne({ where: { token, type, userId: payload.sub, blacklisted: false } });
   if (!tokenDoc) {
     throw new Error('Token not found');
   }

--- a/server/src/services/user.service.js
+++ b/server/src/services/user.service.js
@@ -37,7 +37,7 @@ const queryUsers = async (filter, options) => {
  * @returns {Promise<User>}
  */
 const getUserById = async (id) => {
-  return User.findById(id);
+  return User.findByPk(id);
 };
 
 /**
@@ -78,7 +78,7 @@ const deleteUserById = async (userId) => {
   if (!user) {
     throw new ApiError(httpStatus.NOT_FOUND, 'User not found');
   }
-  await user.remove();
+  await user.destroy();
   return user;
 };
 

--- a/server/src/validations/auth.validation.js
+++ b/server/src/validations/auth.validation.js
@@ -17,18 +17,6 @@ const login = {
   }),
 };
 
-const logout = {
-  body: Joi.object().keys({
-    refreshToken: Joi.string().required(),
-  }),
-};
-
-const refreshTokens = {
-  body: Joi.object().keys({
-    refreshToken: Joi.string().required(),
-  }),
-};
-
 const forgotPassword = {
   body: Joi.object().keys({
     email: Joi.string().email().required(),
@@ -53,8 +41,6 @@ const verifyEmail = {
 module.exports = {
   register,
   login,
-  logout,
-  refreshTokens,
   forgotPassword,
   resetPassword,
   verifyEmail,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,6 +2563,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-slick@^0.23.10":
+  version "0.23.10"
+  resolved "https://registry.yarnpkg.com/@types/react-slick/-/react-slick-0.23.10.tgz#56126e6e4e95cdce7771535b2811c2c1931a7caa"
+  integrity sha512-ZiqdencANDZy6sWOWJ54LDvebuXFEhDlHtXU9FFipQR2BcYU2QJxZhvJPW6YK7cocibUiNn+YvDTbt1HtCIBVA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.2.12":
   version "18.2.14"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.2.14.tgz"
@@ -4261,10 +4268,23 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+cookie-parser@^1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.6.tgz#3ac3a7d35a7a03bbc7e365073a26074824214594"
+  integrity sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==
+  dependencies:
+    cookie "0.4.1"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
+
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookie@0.5.0:
   version "0.5.0"
@@ -5050,6 +5070,11 @@ enhanced-resolve@^5.14.1:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+enquire.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
+  integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
 
 enquirer@2.3.6:
   version "2.3.6"
@@ -6239,7 +6264,7 @@ glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -8533,7 +8558,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -9985,15 +10010,6 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-postcss@^8.3.5, postcss@^8.4.21, postcss@^8.4.23, postcss@^8.4.4:
-  version "8.4.24"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz"
-  integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
-  dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -10399,6 +10415,17 @@ react-scripts@5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-slick@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.29.0.tgz#0bed5ea42bf75a23d40c0259b828ed27627b51bb"
+  integrity sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==
+  dependencies:
+    classnames "^2.2.5"
+    enquire.js "^2.1.6"
+    json2mq "^0.2.0"
+    lodash.debounce "^4.0.8"
+    resize-observer-polyfill "^1.5.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
- Added tokens storage logic
    - Refresh token - cookie, HTTPOnly, managed by backend - created, set/delete cookie
    - Access token - store, managed by frontend - sending with every request with Authorization header, managed by backend - create token

- Added silent authentication (refresh tokens and keep user logged in)

For this task I only was focused on `/register, /login, /send-verification-email` and `/refresh-tokens`, because it has been previously completed (FE + BE)

- Updated some DB queries, according sequelize API